### PR TITLE
prevent proovread from skipping stubby reads

### DIFF
--- a/bin/proovread
+++ b/bin/proovread
@@ -1376,6 +1376,8 @@ sub read_long{
 
         my $noccs;
 
+        my $stubby_length = cfg('lr-min-length') // 2*$min_sr_length;
+
 	foreach(@$opt_lr_file){
 
 		my $lrpr;
@@ -1406,7 +1408,7 @@ sub read_long{
                                     $noccs++;
                                 }
 
-                                if(length($lr->seq) < 2*$min_sr_length){
+                                if(length($lr->seq) < $stubby_length){
 					$stubby_count++;
 					printf IGNORE "%s\t%s\n", $lr->id, "stubby";
 					next;
@@ -1425,7 +1427,7 @@ sub read_long{
                                                               );
                         }
 			close IGNORE;
-			$V->verbose("Skipped $stubby_count stubby reads with length <".2*$min_sr_length) if $stubby_count;
+			$V->verbose("Skipped $stubby_count stubby reads with length <".$stubby_length) if $stubby_count;
 
 		}else{ # FASTQ ref
 			if($opt_mode eq 'sam' or $opt_mode eq 'bam' ){
@@ -1463,7 +1465,7 @@ sub read_long{
                                             $noccs++;
                                         }
 
-                                        if(length($lr->seq) < 2*$min_sr_length){
+                                        if(length($lr->seq) < $stubby_length){
 						$stubby_count++;
 						printf IGNORE "%s\t%s\n", $lr->id, "stubby";
 						next;
@@ -1479,7 +1481,7 @@ sub read_long{
 					$lr{$lr->id} = $lr;
 				}
 				close IGNORE;
-				$V->verbose("Skipped $stubby_count stubby reads with length <".2*$min_sr_length) if $stubby_count;
+				$V->verbose("Skipped $stubby_count stubby reads with length <".$stubby_length) if $stubby_count;
 
 			}
 		}

--- a/proovread.cfg
+++ b/proovread.cfg
@@ -163,6 +163,9 @@
 ##  cannot be detected automatically from --long file.
 'lr-qv-offset' => undef,
 
+## Long read min length
+'lr-min-length' => undef, # undef => 2 x short read length
+
 ## Short read quality offset, usually 64 or 33, use 0 for FASTA. Defaults to
 ##  guessing, Specify value if guessing fails. Needs to be the same for all
 ##  short read files provided.


### PR DESCRIPTION
Hello, 
Is there an option, when running proovread to keep all the long reads including the stubby ones (<400bp)?
_$ proovread -l Contigs-.fasta --bam all_sort.bam -p proovread_test -t 40 --coverage 30 --keep-temporary --ignore-sr-length_
Reads < 2* min_sr_lentgh are discarded
I've tried modifying the parameter in the file ($sr_length) without success.
Thanks
Sabrina
