### PR TITLE
Allow whitespace in ref path (Fixes #116)

### DIFF
--- a/bin/bam2cns
+++ b/bin/bam2cns
@@ -6,6 +6,8 @@ use strict;
 use Pod::Usage;
 use Getopt::Long;
 
+use File::Glob ':bsd_glob';
+
 use FindBin qw($RealBin);
 use lib "$RealBin/../lib/";
 
@@ -241,7 +243,7 @@ my $opt_ref_file;
 my $rpr;
 
 if($opt_ref_pat){
-	($opt_ref_file) = glob("'${opt_ref_pat}'");
+	($opt_ref_file) = bsd_glob($opt_ref_pat);
 	$v->exit("Reference file not found ($opt_ref_pat)") unless $opt_ref_file;
 	# init fastq/fasta parser
 	$rpr = Fastq::Parser->new(file => $opt_ref_file)->check_format;

--- a/bin/bam2cns
+++ b/bin/bam2cns
@@ -241,7 +241,7 @@ my $opt_ref_file;
 my $rpr;
 
 if($opt_ref_pat){
-	($opt_ref_file) = glob($opt_ref_pat);
+	($opt_ref_file) = glob("'${opt_ref_pat}'");
 	$v->exit("Reference file not found ($opt_ref_pat)") unless $opt_ref_file;
 	# init fastq/fasta parser
 	$rpr = Fastq::Parser->new(file => $opt_ref_file)->check_format;


### PR DESCRIPTION
This updates bam2cns to allow the path to the reference to contain whitespace.  In some manual testing in my shell it seems like the globbing still works, too.